### PR TITLE
feat: add authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 PORT=3000
 
 DATABASE_URL="postgresql://username:password@localhost:5432/mydb?schema=public"
+
+NODE_ENV=development
+
+JWT_SECRET=JQDWzJMMe5B8b7hpcapXos7DZupHDwoX
+JWT_REFRESH_SECRET=74N6ZRW7gOw7U09d3JGgzahvZmjY15UW

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,8 +1,24 @@
 import { PrismaClient } from '../generated/prisma';
+import { hashPassword } from '../src/common/auth/password';
 
 const prisma = new PrismaClient();
 
-async function main() {}
+async function main() {
+  // Seed admin user
+  const adminEmail = 'admin@gmail.com';
+  const adminUsername = 'admin';
+  const adminPassword = 'admin123';
+
+  const hashedPassword = await hashPassword(adminPassword);
+  await prisma.user.create({
+    data: {
+      user_name: adminUsername,
+      email: adminEmail,
+      password: hashedPassword,
+      role: 'Admin',
+    },
+  });
+}
 
 main()
   .catch((e) => {

--- a/src/common/auth/jwt.ts
+++ b/src/common/auth/jwt.ts
@@ -1,0 +1,31 @@
+import jwt from 'jsonwebtoken';
+import { UserRole } from '../../../generated/prisma';
+
+const JWT_SECRET = process.env.JWT_SECRET!;
+const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET!;
+const ACCESS_TOKEN_EXPIRY = '15m';
+const REFRESH_TOKEN_EXPIRY = '7d';
+
+export interface TokenPayload {
+  userId: string;
+  email: string;
+  role: UserRole;
+}
+
+export function generateAccessToken(payload: TokenPayload): string {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: ACCESS_TOKEN_EXPIRY });
+}
+
+export function generateRefreshToken(payload: TokenPayload): string {
+  return jwt.sign(payload, JWT_REFRESH_SECRET, {
+    expiresIn: REFRESH_TOKEN_EXPIRY,
+  });
+}
+
+export function verifyAccessToken(token: string): TokenPayload {
+  return jwt.verify(token, JWT_SECRET) as TokenPayload;
+}
+
+export function verifyRefreshToken(token: string): TokenPayload {
+  return jwt.verify(token, JWT_REFRESH_SECRET) as TokenPayload;
+}

--- a/src/common/auth/password.ts
+++ b/src/common/auth/password.ts
@@ -1,0 +1,14 @@
+import bcrypt from 'bcrypt';
+
+const SALT_ROUNDS = 12;
+
+export async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, SALT_ROUNDS);
+}
+
+export async function comparePassword(
+  password: string,
+  hashedPassword: string
+): Promise<boolean> {
+  return bcrypt.compare(password, hashedPassword);
+}

--- a/src/common/errors/validationError.ts
+++ b/src/common/errors/validationError.ts
@@ -9,7 +9,7 @@ export class ValidationError extends CustomError {
   statusCode = 400;
 
   constructor(public details: ValidationErrorDetail[]) {
-    super("Validation failed");
+    super(details.map(d => d.message).join(", "));
   }
 
   generateErrors() {

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,0 +1,97 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+  signInService,
+  refreshTokenService,
+  signOutService,
+} from '../services/authService';
+import { UnauthorizedError } from '../common/errors';
+import { successResponse } from '../common/apiResponse';
+
+// Cookie configuration
+const REFRESH_TOKEN_COOKIE_CONFIG = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production', // HTTPS in production
+  sameSite: 'strict' as const,
+  maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+};
+
+export async function signInController(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const { user, accessToken, refreshToken } = await signInService(
+      req.validatedBody
+    );
+
+    // Set refresh token in HTTP-only cookie
+    res.cookie('refreshToken', refreshToken, REFRESH_TOKEN_COOKIE_CONFIG);
+
+    successResponse(
+      res,
+      'Sign in successful',
+      {
+        user,
+        accessToken,
+      },
+      200
+    );
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function refreshTokenController(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const refreshToken = req.cookies.refreshToken;
+
+    if (!refreshToken) {
+      throw new UnauthorizedError('Refresh token is required');
+    }
+
+    const { newAccessToken, newRefreshToken } =
+      await refreshTokenService(refreshToken);
+
+    // Set new refresh token in HTTP-only cookie
+    res.cookie('refreshToken', newRefreshToken, REFRESH_TOKEN_COOKIE_CONFIG);
+
+    successResponse(
+      res,
+      'Token refreshed successfully',
+      {
+        accessToken: newAccessToken,
+      },
+      200
+    );
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function signOutController(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      throw new UnauthorizedError('User not authenticated');
+    }
+
+    await signOutService(userId);
+
+    // Clear the refresh token cookie
+    res.clearCookie('refreshToken', REFRESH_TOKEN_COOKIE_CONFIG);
+
+    successResponse(res, 'Sign out successfully', null, 200);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { createUserService } from '../services/userService';
+import { successResponse } from '../common/apiResponse';
 
 export async function createUserController(
   req: Request,
@@ -8,10 +9,7 @@ export async function createUserController(
 ): Promise<void> {
   try {
     const newUser = await createUserService(req.validatedBody);
-    res.status(201).json({
-      message: 'User created successfully',
-      data: newUser,
-    });
+    successResponse(res, 'User created successfully', newUser, 201);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from 'express';
+import { createUserService } from '../services/userService';
+
+export async function createUserController(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const newUser = await createUserService(req.validatedBody);
+    res.status(201).json({
+      message: 'User created successfully',
+      data: newUser,
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,10 @@ import cookieParser from 'cookie-parser';
 import dotenv from 'dotenv';
 import { errorHandler } from './middlewares/errorHandlingMiddleware';
 
+// ROUTE IMPORTS
+import authRoute from './routes/authRoute';
+import userRoute from './routes/userRoute';
+
 dotenv.config();
 
 const app = express();
@@ -16,7 +20,9 @@ app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-/* ROUTES */
+// ROUTES
+app.use('/api/v1/auth', authRoute);
+app.use('/api/v1/users', userRoute);
 
 // ERROR HANDLER MUST BE THE LAST MIDDLEWARE
 app.use(errorHandler);

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import { UnauthorizedError } from '../common/errors';
+import { verifyAccessToken } from '../common/auth/jwt';
+import { UserRole } from '../../generated/prisma';
+
+export function isAuthenticated(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1]; // Bearer TOKEN
+
+  if (!token) {
+    throw new UnauthorizedError('Access token is required');
+  }
+
+  try {
+    const decoded = verifyAccessToken(token);
+    req.user = decoded;
+    next();
+  } catch (error) {
+    throw new UnauthorizedError('Invalid or expired token');
+  }
+}
+
+export function hasRole(allowedRoles: UserRole[]) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    if (!req.user?.role || !allowedRoles.includes(req.user.role)) {
+      throw new UnauthorizedError(`Required roles: ${allowedRoles.join(', ')}`);
+    }
+    next();
+  };
+}

--- a/src/routes/authRoute.ts
+++ b/src/routes/authRoute.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { validateRequestBody } from '../middlewares/validationMiddlware';
+import { isAuthenticated } from '../middlewares/authMiddleware';
+import { SignInSchema } from '../validations/authSchema';
+import {
+  refreshTokenController,
+  signInController,
+  signOutController,
+} from '../controllers/authController';
+
+const router = Router();
+
+router.post('/signin', validateRequestBody(SignInSchema), signInController);
+router.post('/refresh-token', refreshTokenController);
+router.post('/signout', isAuthenticated, signOutController);
+
+export default router;

--- a/src/routes/userRoute.ts
+++ b/src/routes/userRoute.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { validateRequestBody } from '../middlewares/validationMiddlware';
+import { hasRole, isAuthenticated } from '../middlewares/authMiddleware';
+import { CreateUserSchema } from '../validations/userSchema';
+import { createUserController } from '../controllers/userController';
+
+const router = Router();
+
+router.post(
+  '/',
+  isAuthenticated,
+  hasRole(['Admin']),
+  validateRequestBody(CreateUserSchema),
+  createUserController
+);
+
+export default router;

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,111 @@
+import prisma from '../lib/prismaClient';
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  verifyRefreshToken,
+  TokenPayload,
+} from '../common/auth/jwt';
+import { comparePassword } from '../common/auth/password';
+import { UnauthorizedError } from '../common/errors';
+import { SignInType } from '../validations/authSchema';
+
+export async function signInService(data: SignInType) {
+  // Find user by email
+  const user = await prisma.user.findUnique({
+    where: { email: data.email },
+  });
+
+  if (!user) {
+    throw new UnauthorizedError('Invalid email or password');
+  }
+
+  // Check password
+  const isPasswordValid = await comparePassword(data.password, user.password);
+  if (!isPasswordValid) {
+    throw new UnauthorizedError('Invalid email or password');
+  }
+
+  // Generate tokens
+  const tokenPayload: TokenPayload = {
+    userId: user.id,
+    email: user.email,
+    role: user.role,
+  };
+
+  const accessToken = generateAccessToken(tokenPayload);
+  const refreshToken = generateRefreshToken(tokenPayload);
+
+  // Update refresh token in database and return user data without password and refresh_token
+  const updatedUser = await prisma.user.update({
+    where: { id: user.id },
+    data: { refresh_token: refreshToken },
+    select: {
+      email: true,
+      id: true,
+      user_name: true,
+      role: true,
+      is_active: true,
+      created_at: true,
+      updated_at: true,
+    },
+  });
+
+  return {
+    user: updatedUser,
+    accessToken,
+    refreshToken,
+  };
+}
+
+export async function refreshTokenService(refreshToken: string) {
+  // Verify refresh token
+  let payload: TokenPayload;
+  try {
+    payload = verifyRefreshToken(refreshToken);
+  } catch (error) {
+    throw new UnauthorizedError('Invalid refresh token');
+  }
+
+  // Find user and verify refresh token matches
+  const user = await prisma.user.findUnique({
+    where: { id: payload.userId },
+    select: {
+      id: true,
+      email: true,
+      role: true,
+      refresh_token: true,
+    }
+  });
+
+  if (!user || user.refresh_token !== refreshToken) {
+    throw new UnauthorizedError('Invalid refresh token');
+  }
+
+  // Generate new tokens
+  const tokenPayload: TokenPayload = {
+    userId: user.id,
+    email: user.email,
+    role: user.role,
+  };
+
+  const newAccessToken = generateAccessToken(tokenPayload);
+  const newRefreshToken = generateRefreshToken(tokenPayload);
+
+  // Update refresh token in database
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { refresh_token: newRefreshToken },
+  });
+
+  return {
+    newAccessToken,
+    newRefreshToken,
+  };
+}
+
+export async function signOutService(userId: string) {
+  await prisma.user.update({
+    where: { id: userId },
+    data: { refresh_token: null },
+  });
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,41 @@
+import { hashPassword } from '../common/auth/password';
+import { BadRequestError } from '../common/errors';
+import prisma from '../lib/prismaClient';
+import { CreateUserType } from '../validations/userSchema';
+
+export async function createUserService(data: CreateUserType) {
+  // Check if user with the same email already exists
+  const existingUser = await prisma.user.findUnique({
+    where: { email: data.email },
+  });
+
+  if (existingUser) {
+    throw new BadRequestError('User with this email already exists');
+  }
+
+  // Hash password
+  const hashedPassword = await hashPassword(data.password);
+
+  // Create new user and Return user data without password and refreshToken
+  const newUser = await prisma.user.create({
+    data: {
+      user_name: data.user_name,
+      email: data.email,
+      password: hashedPassword,
+      role: data.role,
+    },
+    select: {
+      id: true,
+      user_name: true,
+      email: true,
+      role: true,
+      is_active: true,
+      created_at: true,
+      updated_at: true,
+    },
+  });
+
+  return {
+    user: newUser,
+  };
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,8 +1,11 @@
 import 'express';
+import { TokenPayload } from '../common/auth/jwt';
 
 declare global {
   namespace Express {
     interface Request {
+      user?: TokenPayload;
+
       validatedBody?: any;
       validatedQuery?: any;
       validatedParams?: any;

--- a/src/validations/authSchema.ts
+++ b/src/validations/authSchema.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+
+export const SignInSchema = z.object({
+  email: z.email('Invalid email address').min(1, 'Email is required'),
+  password: z.string().min(1, 'Password is required'),
+});
+
+export type SignInType = z.infer<typeof SignInSchema>;
+

--- a/src/validations/userSchema.ts
+++ b/src/validations/userSchema.ts
@@ -1,0 +1,17 @@
+import z from 'zod';
+import { UserRole } from '../../generated/prisma';
+
+export const CreateUserSchema = z.object({
+  user_name: z.string().min(1, 'Username is required'),
+  email: z.email('Invalid email address').min(1, 'Email is required'),
+  password: z.string().min(6, 'Password must be at least 6 characters long'),
+  role: z
+    .enum(
+      [UserRole.Admin, UserRole.Staff, UserRole.Tenant],
+      "Role must be one of 'Admin', 'Staff', or 'Tenant'"
+    )
+    .default(UserRole.Tenant),
+  tenantId: z.string().optional(),
+});
+
+export type CreateUserType = z.infer<typeof CreateUserSchema>;


### PR DESCRIPTION
- Add admin user seed with password hashing
- Implement JWT token generation and verification 
- Implement password hashing and comparing function
- Add auth controllers (signin, refresh, signout) with cookie handling
- Create authentication middleware with role-based access
- Add user creation endpoint with admin authorization
- Set up auth and user routes with validation