### PR TITLE
refactor: For receipts, fix create and update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ app.use(customLogger('API_Logger'));
 app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.set('trust proxy', 1 /* number of proxies between user and server */) // To solve 'X-Forwarded-For' header error in production
+app.set('trust proxy', 1 /* number of proxies between user and server */); // To solve 'X-Forwarded-For' header error in production
 app.use(crediential);
 app.use(cors(corsOptions));
 
@@ -38,8 +38,8 @@ swaggerDocs(app, port || 3000);
 app.use('/api/v1/auth', authRoute);
 app.use('/api/v1/users', isAuthenticated, userRoute);
 app.use('/api/v1/tenants', isAuthenticated, tenantRoute); //tenant endpoint
-app.use('/api/v1', isAuthenticated, serviceRoute)  //customer service end point
-app.use('/api/v1', receiptRoute);
+app.use('/api/v1', isAuthenticated, serviceRoute); //customer service end point
+app.use('/api/v1', isAuthenticated, receiptRoute); //receipt endpoint
 
 // ERROR HANDLER MUST BE THE LAST MIDDLEWARE
 app.use(errorHandler);

--- a/src/services/receiptService.ts
+++ b/src/services/receiptService.ts
@@ -71,9 +71,13 @@ export async function updateReceiptService(
 
   if (!existingReceipt) throw new NotFoundError('Receipt not found');
 
+  // Update only payment_method and paid_date
   return await prisma.receipt.update({
     where: { id: receiptId },
-    data,
+    data: {
+      payment_method: data.payment_method,
+      paid_date: data.paid_date,
+    },
   });
 }
 

--- a/src/validations/receiptSchema.ts
+++ b/src/validations/receiptSchema.ts
@@ -13,10 +13,6 @@ export const GetReceiptByTenantParamSchema = z.object({
   tenantId: z.uuid({ version: 'v4' }),
 });
 
-// export const GetReceiptQuerySchema = z.object({
-//   email: z.email().optional(),
-// });
-
 export const CreateReceiptSchema = z.object({
   payment_method: z.enum(
     [PaymentMethod.Cash, PaymentMethod.Mobile_Banking],
@@ -35,7 +31,6 @@ export const UpdateReceiptSchema = z
       )
       .optional(),
     paid_date: z.coerce.date().optional(),
-    // invoice_id: z.string().optional(),
   })
   .refine((data) => Object.keys(data).length > 0, {
     error: 'At least one field must be provided for update',


### PR DESCRIPTION
i used prisma.$transaction in creating receipts. This method ensures multiple db operations ALL SUCCEED OR ALL FALL.

In update service, i select payment_method and paid_date to update, not the whole data because invoice_id should not be mutated after receipt creation